### PR TITLE
refs #4 Reverse PKs and FKs for SQLServer

### DIFF
--- a/src/main/java/com/change_vision/astah/extension/plugin/dbreverse/reverser/ImportToProject.java
+++ b/src/main/java/com/change_vision/astah/extension/plugin/dbreverse/reverser/ImportToProject.java
@@ -51,7 +51,7 @@ public class ImportToProject {
         }
         List<ERRelationshipInfo> relationships;
         try {
-            relationships = getRelationships(currentDBType, schema);
+            relationships = getRelationships(currentDBType, tables);
         } catch (SQLException e) {
             monitor.showErrorMessage(e);
             logger.error("Error has occured when scanning relationship",e);
@@ -113,12 +113,8 @@ public class ImportToProject {
         }
     }
 
-    private List<ERRelationshipInfo> getRelationships(String currentDBType, String schema) throws SQLException {
-        if (isScanCategoryType(currentDBType)) {
-            return reader.getRelationships(schema, null);
-        } else {
-            return reader.getRelationships(null, schema);
-        }
+    private List<ERRelationshipInfo> getRelationships(String currentDBType, List<TableInfo> tables) throws SQLException {
+        return reader.getRelationships(tables);
     }
 
     private boolean isScanCategoryType(String currentDBType) {

--- a/src/main/java/com/change_vision/astah/extension/plugin/dbreverse/reverser/model/TableInfo.java
+++ b/src/main/java/com/change_vision/astah/extension/plugin/dbreverse/reverser/model/TableInfo.java
@@ -5,6 +5,10 @@ import java.util.List;
 
 
 public class TableInfo {
+    
+    private String catalog;
+    
+    private String schema;
 
 	private String name;
 
@@ -17,20 +21,26 @@ public class TableInfo {
 
 	private List<IndexInfo> indexes;
 
-	public TableInfo() {
-		name = "";
+	public TableInfo(String catalog,String schema, String name) {
+	    this.catalog = catalog;
+	    this.schema = schema;
+		this.name = name;
 		type = "";
 		definition = "";
 		attributes = new ArrayList<AttributeInfo>();
 		indexes = new ArrayList<IndexInfo>();
 	}
 
+	public String getCatalog() {
+        return catalog;
+    }
+	
+	public String getSchema() {
+        return schema;
+    }
+	
 	public String getName() {
 		return name;
-	}
-
-	public void setName(String name) {
-		this.name = name;
 	}
 
 	public String getDefinition() {
@@ -78,8 +88,9 @@ public class TableInfo {
 
     @Override
     public String toString() {
-        return "TableInfo [name=" + name + ", type=" + type + ", definition=" + definition
-                + ", attributes=" + attributes + ", indexes=" + indexes + "]";
+        return "TableInfo [category=" + catalog + ", name=" + name + ", type=" + type
+                + ", definition=" + definition + ", attributes=" + attributes + ", indexes="
+                + indexes + "]";
     }
 
     @Override
@@ -87,6 +98,7 @@ public class TableInfo {
         final int prime = 31;
         int result = 1;
         result = prime * result + ((attributes == null) ? 0 : attributes.hashCode());
+        result = prime * result + ((catalog == null) ? 0 : catalog.hashCode());
         result = prime * result + ((definition == null) ? 0 : definition.hashCode());
         result = prime * result + ((indexes == null) ? 0 : indexes.hashCode());
         result = prime * result + ((name == null) ? 0 : name.hashCode());
@@ -96,26 +108,46 @@ public class TableInfo {
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj) return true;
-        if (obj == null) return false;
-        if (getClass() != obj.getClass()) return false;
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
         TableInfo other = (TableInfo) obj;
         if (attributes == null) {
-            if (other.attributes != null) return false;
-        } else if (!attributes.equals(other.attributes)) return false;
+            if (other.attributes != null)
+                return false;
+        } else if (!attributes.equals(other.attributes))
+            return false;
+        if (catalog == null) {
+            if (other.catalog != null)
+                return false;
+        } else if (!catalog.equals(other.catalog))
+            return false;
         if (definition == null) {
-            if (other.definition != null) return false;
-        } else if (!definition.equals(other.definition)) return false;
+            if (other.definition != null)
+                return false;
+        } else if (!definition.equals(other.definition))
+            return false;
         if (indexes == null) {
-            if (other.indexes != null) return false;
-        } else if (!indexes.equals(other.indexes)) return false;
+            if (other.indexes != null)
+                return false;
+        } else if (!indexes.equals(other.indexes))
+            return false;
         if (name == null) {
-            if (other.name != null) return false;
-        } else if (!name.equals(other.name)) return false;
+            if (other.name != null)
+                return false;
+        } else if (!name.equals(other.name))
+            return false;
         if (type == null) {
-            if (other.type != null) return false;
-        } else if (!type.equals(other.type)) return false;
+            if (other.type != null)
+                return false;
+        } else if (!type.equals(other.type))
+            return false;
         return true;
     }
+
+
 	
 }

--- a/src/test/java/com/change_vision/astah/extension/plugin/dbreverse/reverser/DBConnectionTest.java
+++ b/src/test/java/com/change_vision/astah/extension/plugin/dbreverse/reverser/DBConnectionTest.java
@@ -1,6 +1,8 @@
 package com.change_vision.astah.extension.plugin.dbreverse.reverser;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 import java.net.MalformedURLException;
@@ -15,6 +17,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import com.change_vision.astah.extension.plugin.dbreverse.reverser.model.ConnectionInfo;
+import com.change_vision.astah.extension.plugin.dbreverse.reverser.model.TableInfo;
 
 public class DBConnectionTest {
 
@@ -65,8 +68,14 @@ public class DBConnectionTest {
     @Test
     public void getTables() throws Exception {
         connection.connect(info);
-        List<String> tables = connection.getTables(null, "PUBLIC");
-        assertThat(tables,hasItem("SAMPLE"));
+        List<TableInfo> tables = connection.getTables(null, "PUBLIC");
+        boolean found = false;
+        for (TableInfo table : tables) {
+            if (table.getName().equals("SAMPLE")) {
+                found = true;
+            }
+        }
+        assertThat(found,is(true));
     }
     
     @Test

--- a/src/test/java/com/change_vision/astah/extension/plugin/dbreverse/reverser/DBReaderTest.java
+++ b/src/test/java/com/change_vision/astah/extension/plugin/dbreverse/reverser/DBReaderTest.java
@@ -1,6 +1,8 @@
 package com.change_vision.astah.extension.plugin.dbreverse.reverser;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 import java.net.MalformedURLException;
@@ -88,7 +90,8 @@ public class DBReaderTest {
     @Test
     public void getRelations() throws Exception {
         reader.connect(info);
-        List<ERRelationshipInfo> relationships = reader.getRelationships(CATALOG, SCHEMA);
+        List<TableInfo> tables = reader.getTables(CATALOG, SCHEMA);
+        List<ERRelationshipInfo> relationships = reader.getRelationships(tables);
         assertThat(relationships.size(),is(1));
         for (ERRelationshipInfo relationshipInfo : relationships) {
             System.out.println(relationshipInfo);
@@ -98,17 +101,27 @@ public class DBReaderTest {
     @Test
     public void getFKs() throws Exception {
         reader.connect(info);
-        HashMap<String, String> foreignKeys = reader.getFKs(CATALOG,SCHEMA,TABLE_NAME_OF_SAMPLE_RELATIONSHIPS);
-        assertThat(foreignKeys.size(),is(1));
-        System.out.println(foreignKeys);
+        List<TableInfo> tables = reader.getTables(CATALOG, SCHEMA);
+        for (TableInfo tableInfo : tables) {
+            if (tableInfo.getName().equals(TABLE_NAME_OF_SAMPLE_RELATIONSHIPS)) {
+                HashMap<String, String> foreignKeys = reader.getFKs(tableInfo);
+                assertThat(foreignKeys.size(),is(1));
+                System.out.println(foreignKeys);
+            }
+        }
     }
     
     @Test
     public void getPKs() throws Exception {
         reader.connect(info);
-        HashSet<String> primaryKeys = reader.getPKs(CATALOG, SCHEMA, TABLE_NAME_OF_SAMPLE);
-        assertThat(primaryKeys.size(),is(1));
-        assertThat(primaryKeys,hasItem("TEST_IDENTITY"));
+        List<TableInfo> tables = reader.getTables(CATALOG, SCHEMA);
+        for (TableInfo tableInfo : tables) {
+            if (tableInfo.getName().equals(TABLE_NAME_OF_SAMPLE)) {
+                HashSet<String> primaryKeys = reader.getPKs(tableInfo);
+                assertThat(primaryKeys.size(),is(1));
+                assertThat(primaryKeys,hasItem("TEST_IDENTITY"));
+            }
+        }
     }
 
 }

--- a/src/test/java/com/change_vision/astah/extension/plugin/dbreverse/reverser/DBToProjectTest.java
+++ b/src/test/java/com/change_vision/astah/extension/plugin/dbreverse/reverser/DBToProjectTest.java
@@ -1,6 +1,8 @@
 package com.change_vision.astah.extension.plugin.dbreverse.reverser;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
 import java.io.File;
@@ -54,7 +56,7 @@ public class DBToProjectTest {
         info.setJdbcurl("jdbc:h2:file:" + dataURL.getPath() + "/h2");
         reader.connect(info);
         tables = reader.getTables("H2", "PUBLIC");
-        relationships = reader.getRelationships("H2", "PUBLIC");
+        relationships = reader.getRelationships(tables);
         File projectFile = folder.newFile("test.asta");
         String projectFilePath = projectFile.getAbsolutePath();
         accessor = ProjectAccessorFactory.getProjectAccessor();

--- a/src/test/java/com/change_vision/astah/extension/plugin/dbreverse/reverser/ImportToProjectTest.java
+++ b/src/test/java/com/change_vision/astah/extension/plugin/dbreverse/reverser/ImportToProjectTest.java
@@ -5,8 +5,8 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
 import java.net.URL;
-import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -53,21 +53,22 @@ public class ImportToProjectTest {
     
     @Test
     public void importFromMySQL() throws Exception {
-        when(reader.getTables(null, "PUBLIC")).thenThrow(new SQLException("Illegal Usege"));
-        when(reader.getRelationships(null, "PUBLIC")).thenThrow(new SQLException("Illegal Usege"));
-        when(reader.getTables("PUBLIC", null)).thenReturn(new ArrayList<TableInfo>());
-        when(reader.getRelationships("PUBLIC", null)).thenReturn(new ArrayList<ERRelationshipInfo>());
+        List<TableInfo> dummyInfo = new ArrayList<TableInfo>();
+        when(reader.getTables("PUBLIC", null)).thenReturn(dummyInfo);
+        when(reader.getRelationships(dummyInfo)).thenReturn(new ArrayList<ERRelationshipInfo>());
+        
         ImportToProject importer = new ImportToProject(reader);
+        
         boolean imported = importer.doImport(DatabaseTypes.MYSQL.getType(), "PUBLIC");
         assertThat(imported,is(true));
     }
     
     @Test
     public void importFromPostgreSQL() throws Exception {
-        when(reader.getTables(null, "PUBLIC")).thenReturn(new ArrayList<TableInfo>());
-        when(reader.getRelationships(null, "PUBLIC")).thenReturn(new ArrayList<ERRelationshipInfo>());
-        when(reader.getTables("PUBLIC", null)).thenThrow(new SQLException("Illegal Usege"));
-        when(reader.getRelationships("PUBLIC", null)).thenThrow(new SQLException("Illegal Usege"));
+        List<TableInfo> dummyInfo = new ArrayList<TableInfo>();
+        when(reader.getTables(null, "PUBLIC")).thenReturn(dummyInfo);
+        when(reader.getRelationships(dummyInfo)).thenReturn(new ArrayList<ERRelationshipInfo>());
+        
         ImportToProject importer = new ImportToProject(reader);
         boolean imported = importer.doImport(DatabaseTypes.POSTGRES.getType(), "PUBLIC");
         assertThat(imported,is(true));

--- a/src/test/java/com/change_vision/astah/extension/plugin/dbreverse/reverser/converter/TableConverterTest.java
+++ b/src/test/java/com/change_vision/astah/extension/plugin/dbreverse/reverser/converter/TableConverterTest.java
@@ -12,7 +12,6 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import com.change_vision.astah.extension.plugin.dbreverse.reverser.converter.TableConverter;
 import com.change_vision.astah.extension.plugin.dbreverse.reverser.model.TableInfo;
 import com.change_vision.jude.api.inf.editor.ERModelEditor;
 import com.change_vision.jude.api.inf.model.IEREntity;
@@ -36,8 +35,7 @@ public class TableConverterTest {
     
     @Test
     public void convertEntity() throws Exception {
-        TableInfo tableInfo = new TableInfo();
-        tableInfo.setName("hoge");
+        TableInfo tableInfo = new TableInfo("","","hoge");
         
         when(editor.createEREntity(schema, "hoge","hoge")).thenReturn(entity);
         TableConverter converter = new TableConverter(editor,schema);


### PR DESCRIPTION
- refs #4 Reverse PKs and FKs for SQLServer
- Load some information from metadata, it needs catalog or scheme name
- JDBC support to load catalog and schema information
  - see http://docs.oracle.com/javase/7/docs/api/java/sql/DatabaseMetaData.html